### PR TITLE
feat✨: update OpenAI chat generation and add task details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+git-message.json

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -6,7 +6,7 @@ use crate::providers::Ticket;
 
 pub struct MessagePayload {
     pub diff: String,
-    pub ticket: Ticket,
+    pub ticket: Option<Ticket>,
     pub instructions: Vec<String>,
 }
 
@@ -20,7 +20,7 @@ pub const AVAILABLE_AI: &[&str; 1] = &["OpenAI"];
 
 pub async fn generate_message(
     configuration: super::Configuration,
-    ticket: Ticket,
+    ticket: Option<Ticket>,
     diff: String,
 ) -> Result<serde_json::Value, reqwest::Error> {
     match &configuration.ai {

--- a/src/ai/open_ai.rs
+++ b/src/ai/open_ai.rs
@@ -44,42 +44,43 @@ pub async fn generate_message(
         ChatMessage {
             role: String::from("system"),
             content: String::from(
-                r#"You are a git message generator which receives the user input and output a great message
-        following the patterns provided by the user input considering these contexts:
-  the git diff of the commits and the related task or ticket.
+                r#"You should act as a senios software developer that will generate git commit messages following
+the semantic commit convention to generate beautiful commit message that if easy to read.
+Wenever you receive a Ticket information, you should use these information to help contextualize the
+updates you will receive on git diff.
+You should use emojis whenever it is usefull to help the developers understand what was implemented in the git diff.
+You should take care of not violate the semantic commit rules when use emojis.
+You should not include any extra content on your response, only the final commit message ready to be included on a git commit.
   "#,
             ),
         },
         ChatMessage {
             role: "user".to_string(),
             content: format!(
-                "Follow this pattern as strict as prossible:\n* {}",
-                payload.instructions.join("\n * ")
-            ),
-        },
-        ChatMessage {
-            role: "user".to_string(),
-            content: format!(
                 r#"
-        Based on the following git commit diff, generate a beautiful and compreensive
-        git commit message following the Semantic Commit format and using emojis whenever you need.
-        You should not include any content on your response, only the commit contet ready to be used.
-
+This is the git diff:
 ```
 {}
 ```
-
-        The commit message should pass in the Semantic Commit format validation.
             \n\n"#,
                 payload.diff,
             ),
         },
     ];
+    if payload.instructions.len() > 0 {
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: format!(
+                "Follow the following instruction as much as possible:\n* {}",
+                payload.instructions.join("* \n")
+            ),
+        })
+    }
     match &payload.ticket {
         Some(ticket) => messages.push(ChatMessage {
             role: "user".to_string(),
             content: format!(
-                "Task title: {}\nTask description: {}\n",
+                "Ticket title: {}\nTicket description: {}\n",
                 ticket.title, ticket.description,
             ),
         }),

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -15,14 +15,14 @@ pub fn run() -> Command {
                 )
                 .short_flag('g')
                 .long_flag("generate")
-                .arg_required_else_help(true)
                 .args_conflicts_with_subcommands(true)
                 .arg(
                     Arg::new("ticket-id")
                         .short('t')
                         .long("ticket-id")
-                        .value_name("RT-42")
+                        .value_name("DP-42")
                         .required(false)
+                        .default_value("")
                         .help("What is the ticket id")
                         .long_help(
                             "This ticket will be read to improve the commit message",
@@ -50,6 +50,6 @@ pub fn run() -> Command {
 pub fn generate(sub_matches: &clap::ArgMatches, _configuration: &Configuration) -> String {
     sub_matches
         .get_one::<String>("ticket-id")
-        .expect("ticket-id is required")
+        .unwrap()
         .to_string()
 }

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -6,11 +6,12 @@ pub fn run() -> Command {
     Command::new("git-message-ai")
         .about("A CLI to generate your git messages!")
         .author("codermarcos")
+        .arg_required_else_help(true)
         .subcommand(
             Command::new("generate")
                 .about("Generates a message with predefined arguments")
                 .long_about(
-                    "This command generates a message with predefined arguments. The ticket id is required.",
+                    "This command generates a message with predefined arguments. The ticket id is not required.",
                 )
                 .short_flag('g')
                 .long_flag("generate")
@@ -20,8 +21,8 @@ pub fn run() -> Command {
                     Arg::new("ticket-id")
                         .short('t')
                         .long("ticket-id")
-                        .value_name("RT-666")
-                        .required(true)
+                        .value_name("RT-42")
+                        .required(false)
                         .help("What is the ticket id")
                         .long_help(
                             "This ticket will be read to improve the commit message",

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,7 +2,7 @@ use std::iter::FromIterator;
 use tokio::process::Command;
 pub async fn get_diff() -> Result<String, std::io::Error> {
     let output = Command::new("git")
-        .args(["diff", "--cached"])
+        .args(["status", "-v"])
         .output()
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,8 @@ impl Configuration {
 
     pub fn read() -> Configuration {
         let configuration_file_path = Path::new("./git-message.json");
-        let file = fs::read_to_string(configuration_file_path).expect("Failed to read configuration");
+        let file =
+            fs::read_to_string(configuration_file_path).expect("Failed to read configuration");
 
         serde_json::from_str(&file).unwrap()
     }
@@ -56,13 +57,21 @@ async fn main() -> Result<(), Error> {
 
             let message = ai::generate_message(configuration, ticket, diff.unwrap()).await?;
 
-            println!("{:#?}", message);
+            let content = message.get("choices").unwrap()[0]
+                .get("message")
+                .unwrap()
+                .get("content")
+                .unwrap()
+                .to_string()
+                .replace("\"", "")
+                .replace("\\n", "\n");
+            println!("{}", content);
         }
         Some(("initiate", _)) => {
             cli::interactive::initiate();
 
             println!("✅ Configuration saved with success!");
-        },
+        }
         _ => panic!("command not found! Please try using --help"),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ impl Configuration {
     pub fn read() -> Configuration {
         let configuration_file_path = Path::new("./git-message.json");
         let file = fs::read_to_string(configuration_file_path).expect("Failed to read configuration");
-    
+
         serde_json::from_str(&file).unwrap()
     }
 }
@@ -41,13 +41,18 @@ async fn main() -> Result<(), Error> {
     match matches.subcommand() {
         Some(("generate", sub_matches)) => {
             let configuration = Configuration::read();
-        
+
             let (diff, ticket_id) = tokio::join!(
                 git::get_diff(),
                 cli::get_ticket_id(&sub_matches, &configuration)
             );
 
-            let ticket = providers::get_ticket(&configuration.ticket, ticket_id).await?;
+            let get_ticket_result = providers::get_ticket(&configuration.ticket, ticket_id).await?;
+            let ticket = if get_ticket_result.title.is_empty() {
+                None
+            } else {
+                Some(get_ticket_result)
+            };
 
             let message = ai::generate_message(configuration, ticket, diff.unwrap()).await?;
 
@@ -55,7 +60,7 @@ async fn main() -> Result<(), Error> {
         }
         Some(("initiate", _)) => {
             cli::interactive::initiate();
-            
+
             println!("✅ Configuration saved with success!");
         },
         _ => panic!("command not found! Please try using --help"),

--- a/src/providers/jira.rs
+++ b/src/providers/jira.rs
@@ -15,7 +15,13 @@ pub struct JiraConfiguration {
     pub prefix: Option<String>,
 }
 
-pub async fn get_ticket(id: String, configuration: &JiraConfiguration) -> Result<Value, Error> {
+pub async fn get_ticket(
+    id: String,
+    configuration: &JiraConfiguration,
+) -> Result<Option<Value>, Error> {
+    if id == "skip" { // sory for this, lest think in a better strategy to deal with this case
+        return Ok(None);
+    }
     let url = format!(
         "https://{}.atlassian.net/rest/api/2/issue/{}",
         configuration.host, id
@@ -34,28 +40,33 @@ pub async fn get_ticket(id: String, configuration: &JiraConfiguration) -> Result
     let response = client.get(url).headers(headers).send().await;
 
     match response {
-        Ok(r) => r.json::<Value>().await,
+        Ok(r) => Ok(Some((r.json::<Value>().await).unwrap())),
         Err(e) => {
             println!("ERROR: Getting JIRA Issue {}", e.to_string());
-            Ok(Value::Null)
+            Ok(Some(Value::Null))
         }
     }
 }
 
-pub fn get_fields(ticket: Value) -> Ticket {
+pub fn get_fields(ticket: Option<Value>) -> Ticket {
     let mut fields = Ticket {
         title: String::new(),
         description: String::new(),
     };
 
-    if let Some(ticket_fields) = ticket.get("fields") {
-        if let Some(description) = ticket_fields.get("description") {
-            fields.description = description.as_str().unwrap().to_string();
-        }
+    match ticket {
+        Some(value) => {
+            if let Some(ticket_fields) = value.get("fields") {
+                if let Some(description) = ticket_fields.get("description") {
+                    fields.description = description.as_str().unwrap().to_string();
+                }
 
-        if let Some(summary) = ticket_fields.get("summary") {
-            fields.title = summary.as_str().unwrap().to_string();
-        }
+                if let Some(summary) = ticket_fields.get("summary") {
+                    fields.title = summary.as_str().unwrap().to_string();
+                }
+            }
+        },
+        None => {}
     }
 
     fields

--- a/src/providers/jira.rs
+++ b/src/providers/jira.rs
@@ -19,7 +19,7 @@ pub async fn get_ticket(
     id: String,
     configuration: &JiraConfiguration,
 ) -> Result<Option<Value>, Error> {
-    if id == "skip" { // sory for this, lest think in a better strategy to deal with this case
+    if id.is_empty() {
         return Ok(None);
     }
     let url = format!(


### PR DESCRIPTION
👾 **Summary**
- Update logic for generating chat messages using OpenAI API
- Include user instructions and Git commit diff in chat messages
- Enhance handling of task details if provided

🔗 **Details**
- Define struct `ChatMessage` with role and content fields
- Retrieve OpenAI token securely from environment variable
- Create messages vector with system and user messages
- Include user instructions and Git commit diff in chat messages
- Handle task details with Jira ticket information if provided

Closes #1 
